### PR TITLE
Allow disabling pod security context

### DIFF
--- a/charts/sourcebot/templates/deployment.yaml
+++ b/charts/sourcebot/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sourcebot.serviceAccountName" $ }}
-      {{- with $.Values.sourcebot.podSecurityContext }}
+      {{- if $.Values.sourcebot.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml $.Values.sourcebot.podSecurityContext | nindent 8 }}
       {{- end }}
       {{- with $.Values.sourcebot.initContainers }}
       initContainers:


### PR DESCRIPTION
I couldn't disable podSecurityContext, the default sourcebot value was still generated. This should fix the issue 