### PR TITLE
Feat: add support for deployment strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added configurable deployment strategy support, allowing users to switch between `RollingUpdate` and `Recreate` strategies. [#82](https://github.com/sourcebot-dev/sourcebot-helm-chart/pull/82)
+
 ## [0.1.71] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -221,6 +221,37 @@ sourcebot:
     existingSecretKey: license-key
 ```
 
+## Deployment Strategy
+
+By default, the chart uses a `RollingUpdate` strategy, which creates the new pod before terminating the old one during upgrades. You can customize the rolling update behavior:
+```yaml
+sourcebot:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+```
+
+On multi-node clusters with `ReadWriteOnce` persistent volumes, the new pod may fail to start if it gets scheduled on a different node than the old pod. To avoid this, you can pin pods to the same node using pod affinity:
+```yaml
+sourcebot:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: sourcebot
+          topologyKey: kubernetes.io/hostname
+```
+
+Alternatively, you can use the `Recreate` strategy, which terminates the old pod before creating the new one. This avoids PVC conflicts but causes brief downtime during upgrades:
+```yaml
+sourcebot:
+  strategy:
+    type: Recreate
+```
+
 ## Persistence
 
 Each component has its own persistent volume for storing data across pod restarts.
@@ -323,6 +354,31 @@ sourcebot:
       - hosts:
           - sourcebot.example.com
         secretName: sourcebot-tls
+```
+
+### Zero-downtime upgrades on multi-node clusters
+
+Use a `ReadWriteMany` access mode so the old and new pods can mount the PVC simultaneously during rolling updates. This requires a storage class that supports `ReadWriteMany` (e.g., EFS on AWS, Filestore on GCP, Azure Files):
+
+```yaml
+sourcebot:
+  persistence:
+    accessModes:
+      - ReadWriteMany
+    storageClass: "efs-sc"  # example: AWS EFS storage class
+```
+
+Alternatively, you can keep `ReadWriteOnce` and use pod affinity to pin pods to the same node:
+
+```yaml
+sourcebot:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: sourcebot
+          topologyKey: kubernetes.io/hostname
 ```
 
 ### Using an existing PVC

--- a/charts/sourcebot/Chart.yaml
+++ b/charts/sourcebot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: sourcebot
-version: 0.1.66
+version: 0.1.67
 appVersion: v4.16.3
 description: Sourcebot is a self-hosted tool that helps you understand your codebase.
 icon: https://raw.githubusercontent.com/sourcebot-dev/sourcebot/ebf6721836b8f878d42bb8c1e844bdc7867a74fe/packages/web/public/logo_512.png

--- a/charts/sourcebot/README.md
+++ b/charts/sourcebot/README.md
@@ -130,6 +130,7 @@ Sourcebot is a self-hosted tool that helps you understand your codebase.
 | sourcebot.startupProbe.httpGet.path | string | `"/api/health"` | Path to check |
 | sourcebot.startupProbe.httpGet.port | string | `"http"` | Port to check |
 | sourcebot.startupProbe.periodSeconds | int | `30` | Initial delay before the first probe |
+| sourcebot.strategy | object | `{"type":"RollingUpdate"}` | Deployment strategy configuration |
 | sourcebot.tolerations | list | `[]` | Set tolerations for pod scheduling See: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 
 ----------------------------------------------

--- a/charts/sourcebot/templates/deployment.yaml
+++ b/charts/sourcebot/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- include "sourcebot.labels" $ | nindent 4 }}
 spec:
   replicas: {{ $.Values.sourcebot.replicaCount }}
+  {{- with $.Values.sourcebot.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "sourcebot.selectorLabels" $ | nindent 6 }}

--- a/charts/sourcebot/values.schema.json
+++ b/charts/sourcebot/values.schema.json
@@ -36,6 +36,18 @@
           "type": "integer",
           "minimum": 1
         },
+        "strategy": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["RollingUpdate", "Recreate"]
+            },
+            "rollingUpdate": {
+              "type": "object"
+            }
+          }
+        },
         "image": {
           "type": "object",
           "properties": {

--- a/charts/sourcebot/values.schema.json
+++ b/charts/sourcebot/values.schema.json
@@ -38,15 +38,23 @@
         },
         "strategy": {
           "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": ["RollingUpdate", "Recreate"]
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "const": "RollingUpdate" },
+                "rollingUpdate": { "type": "object" }
+              },
+              "required": ["type"]
             },
-            "rollingUpdate": {
-              "type": "object"
+            {
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "const": "Recreate" }
+              },
+              "required": ["type"]
             }
-          }
+          ]
         },
         "image": {
           "type": "object",

--- a/charts/sourcebot/values.yaml
+++ b/charts/sourcebot/values.yaml
@@ -4,7 +4,7 @@ global:
   security:
     # -- Allow insecure images to use bitnami legacy repository. Can be set to false if secure images are being used (Paid).
     allowInsecureImages: true
-  
+
   # -- Global Docker registry secret names as an array
   imagePullSecrets: []
 
@@ -18,6 +18,10 @@ fullnameOverride: ""
 sourcebot:
   # -- Set the number of replicas for the deployment
   replicaCount: 1
+
+  # -- Deployment strategy configuration
+  strategy:
+    type: RollingUpdate
 
   # Image configuration
   image:


### PR DESCRIPTION
Sourcebot mounts a PersistentVolumeClaim for its /data directory. The most common PVC storage class access mode is ReadWriteOnce (RWO), which allows the volume to be mounted by only one node at a time.

With the default RollingUpdate strategy, Kubernetes starts the new pod before terminating the old one. When both pods attempt to bind the same RWO volume simultaneously, the new pod gets stuck in Pending or ContainerCreating.

This makes rolling updates effectively broken for single-node PVC setups — which is the majority of self-hosted deployments.

What this PR does
* Adds a sourcebot.strategy value to configure the Kubernetes [deployment strategy](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
* Defaults to RollingUpdate (Kubernetes default, correct for RWX volumes or no persistence)
* Users with RWO volumes can now switch to Recreate to ensure the old pod is fully terminated before the new one starts, allowing the volume to detach cleanly
```
sourcebot:
  strategy:
    type: Recreate
```

Impact: no breaking change, default behaviour is maintained with type: RollingUpdate    

Fixes #83


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable deployment strategy support, letting users choose RollingUpdate or Recreate with sensible defaults.
* **Documentation**
  * Added docs and examples explaining deployment strategy options, upgrade behavior, and guidance for zero-downtime upgrades on multi-node clusters.
* **Chores**
  * Updated chart values schema and changelog to reflect the new strategy configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->