### PR TITLE
fix(pvc): prevent PV rebinding on upgrade and fix missing annotations block

### DIFF
--- a/charts/sourcebot/templates/pvc.yaml
+++ b/charts/sourcebot/templates/pvc.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.sourcebot.persistence.enabled (not .Values.sourcebot.persistence.existingClaim) }}
+{{- $volumeName := printf "%s-%s" (include "sourcebot.fullname" .) "data" -}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -7,10 +8,11 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "sourcebot.labels" . | nindent 4 }}
-  {{- with .Values.sourcebot.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: keep
+    {{- with .Values.sourcebot.persistence.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   accessModes:
     {{- range .Values.sourcebot.persistence.accessModes }}
@@ -24,6 +26,9 @@ spec:
   storageClassName: ""
   {{- else }}
   storageClassName: {{ .Values.sourcebot.persistence.storageClass }}
+  {{- end }}
+  {{- if (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $volumeName) }}
+  volumeName: {{ (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $volumeName).spec.volumeName }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sourcebot/templates/pvc.yaml
+++ b/charts/sourcebot/templates/pvc.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.sourcebot.persistence.enabled (not .Values.sourcebot.persistence.existingClaim) }}
-{{- $volumeName := printf "%s-%s" (include "sourcebot.fullname" .) "data" -}}
+{{- $pvcName := printf "%s-%s" (include "sourcebot.fullname" .) "data" -}}
+{{- $existingPvc := (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $pvcName) -}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -27,9 +28,9 @@ spec:
   {{- else }}
   storageClassName: {{ .Values.sourcebot.persistence.storageClass }}
   {{- end }}
-  {{- if (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $volumeName) }}
-  volumeName: {{ (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $volumeName).spec.volumeName }}
   {{- end }}
+  {{- if and $existingPvc $existingPvc.spec.volumeName }}
+  volumeName: {{ $existingPvc.spec.volumeName }}
   {{- end }}
 {{- end }}
 

--- a/charts/sourcebot/tests/basic_test.yaml
+++ b/charts/sourcebot/tests/basic_test.yaml
@@ -159,6 +159,31 @@ tests:
               claimName: my-existing-pvc
         template: deployment.yaml
 
+  - it: should always have keep resource policy annotation on PVC
+    values:
+      - ../values.lint.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+        template: pvc.yaml
+
+  - it: should merge custom annotations with helm resource policy on PVC
+    values:
+      - ../values.lint.yaml
+    set:
+      sourcebot.persistence.annotations:
+        custom.io/annotation: "my-value"
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+        template: pvc.yaml
+      - equal:
+          path: metadata.annotations["custom.io/annotation"]
+          value: my-value
+        template: pvc.yaml
+
   - it: should set service type correctly
     values:
       - ../values.lint.yaml


### PR DESCRIPTION
Add `helm.sh/resource-policy: keep` unconditionally so the PVC survives
helm uninstall, fix the annotations block which was previously absent when
no custom annotations were set, and use `lookup` to pin `volumeName` on
upgrades to prevent the PVC from being re-bound to a different PV.

Also add some test coverage.

Fixes #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced persistent volume handling with automatic detection and preservation of existing volume bindings
  * Added resource protection annotation to prevent accidental data loss during updates

* **Tests**
  * Added validation tests for persistence annotations and resource protection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->