### PR TITLE
fix(chart): allow metadata and additional labels

### DIFF
--- a/charts/sourcebot/README.md
+++ b/charts/sourcebot/README.md
@@ -22,8 +22,10 @@ Sourcebot is a self-hosted tool that helps you understand your codebase.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalLabels | object | `{}` | Add extra labels to all resources |
 | fullnameOverride | string | `""` | Override the full name of the deployed resources, defaults to a combination of the release name and the name for the selector labels |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
+| global.metadata | object | `{}` | Global metadata for deployment tooling |
 | global.security.allowInsecureImages | bool | `true` | Allow insecure images to use bitnami legacy repository. Can be set to false if secure images are being used (Paid). |
 | nameOverride | string | `""` | Override the name for the selector labels, defaults to the chart name |
 | postgresql.auth.args | string | `""` | Additional database connection arguments |

--- a/charts/sourcebot/templates/_helpers.tpl
+++ b/charts/sourcebot/templates/_helpers.tpl
@@ -40,7 +40,8 @@ helm.sh/chart: {{ include "sourcebot.chart" $ }}
 app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ $.Release.Service }}
-{{- with $.Values.additionalLabels }}
+{{- $additionalLabels := mergeOverwrite (dict) (default dict $.Values.sourcebot.additionalLabels) (default dict $.Values.additionalLabels) }}
+{{- with $additionalLabels }}
 {{ toYaml . }}
 {{- end }}
 {{- end }}

--- a/charts/sourcebot/tests/basic_test.yaml
+++ b/charts/sourcebot/tests/basic_test.yaml
@@ -67,6 +67,28 @@ tests:
           value: Helm
         template: deployment.yaml
 
+  - it: should include root additional labels
+    values:
+      - ../values.lint.yaml
+    set:
+      additionalLabels.component: sourcebot
+    asserts:
+      - equal:
+          path: metadata.labels.component
+          value: sourcebot
+        template: deployment.yaml
+
+  - it: should include sourcebot additional labels
+    values:
+      - ../values.lint.yaml
+    set:
+      sourcebot.additionalLabels.component: sourcebot
+    asserts:
+      - equal:
+          path: metadata.labels.component
+          value: sourcebot
+        template: deployment.yaml
+
   - it: should use correct image when tag is specified
     values:
       - ../values.lint.yaml
@@ -183,4 +205,3 @@ tests:
       - isNotEmpty:
           path: data["config.json"]
         template: config.yaml
-

--- a/charts/sourcebot/values.schema.json
+++ b/charts/sourcebot/values.schema.json
@@ -19,6 +19,9 @@
         "imagePullSecrets": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "metadata": {
+          "type": "object"
         }
       }
     },
@@ -27,6 +30,9 @@
     },
     "fullnameOverride": {
       "type": "string"
+    },
+    "additionalLabels": {
+      "type": "object"
     },
     "sourcebot": {
       "type": "object",

--- a/charts/sourcebot/values.yaml
+++ b/charts/sourcebot/values.yaml
@@ -8,11 +8,18 @@ global:
   # -- Global Docker registry secret names as an array
   imagePullSecrets: []
 
+  # -- Global metadata for deployment tooling
+  metadata: {}
+
 # -- Override the name for the selector labels, defaults to the chart name
 nameOverride: ""
 
 # -- Override the full name of the deployed resources, defaults to a combination of the release name and the name for the selector labels
 fullnameOverride: ""
+
+# -- Add extra labels to all resources
+additionalLabels: {}
+# team: sourcebot
 
 # Core Sourcebot Configuration
 sourcebot:


### PR DESCRIPTION
## Summary

- Allow `global.metadata` in the chart values schema.
- Add root-level `additionalLabels` to the values schema and documented defaults.
- Keep label handling compatible with the existing `sourcebot.additionalLabels` value while also supporting the root-level value that the chart helper already reads.

## Why

The chart currently has a strict values schema. That is helpful for catching mistakes, but it also rejects common Helm usage where deployment tooling passes shared metadata through `global.metadata`.

There is also a mismatch around `additionalLabels`: `values.yaml` and the schema expose it under `sourcebot.additionalLabels`, but the shared label helper reads from root-level `additionalLabels`. That means the documented value can validate without affecting rendered labels, while the value the templates actually read is rejected by schema validation.

This change keeps the schema strict for known fields while allowing these two intended extension points.

## Validation

- `helm dependency update charts/sourcebot/`
- `helm lint charts/sourcebot/ -f charts/sourcebot/values.lint.yaml`
- `helm unittest charts/sourcebot/ --color`
- `/private/tmp/helm-docs charts/sourcebot/`
- `helm template test charts/sourcebot/ -f charts/sourcebot/values.lint.yaml --set global.metadata.owner=platform --set additionalLabels.component=sourcebot`
- `helm template test charts/sourcebot/ -f charts/sourcebot/values.lint.yaml --set sourcebot.additionalLabels.component=sourcebot`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional labels on Helm chart resources via `additionalLabels`
  * Added support for deployment tooling metadata configuration via `global.metadata`

* **Documentation**
  * Updated configuration documentation with new label and metadata options

* **Tests**
  * Added test coverage for label configuration scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->