### PR TITLE
feat: add lifecycle and terminationGracePeriodSeconds values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `sourcebot.lifecycle` and `sourcebot.terminationGracePeriodSeconds` values.
+
 ## [0.1.85] - 2026-05-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `sourcebot.lifecycle` and `sourcebot.terminationGracePeriodSeconds` values.
+- `sourcebot.lifecycle` and `sourcebot.terminationGracePeriodSeconds` values. [#110](https://github.com/sourcebot-dev/sourcebot-helm-chart/pull/110)
 
 ## [0.1.85] - 2026-05-30
 

--- a/charts/sourcebot/README.md
+++ b/charts/sourcebot/README.md
@@ -87,6 +87,7 @@ Sourcebot is a self-hosted tool that helps you understand your codebase.
 | sourcebot.license.existingSecret | string | `""` | Use an existing secret for the license key |
 | sourcebot.license.existingSecretKey | string | `"key"` | Key in the existing secret that contains the license key |
 | sourcebot.license.value | string | `""` | License key value (or use existingSecret) |
+| sourcebot.lifecycle | object | `{}` | Container lifecycle hooks. |
 | sourcebot.livenessProbe.failureThreshold | int | `5` | Number of consecutive failures before marking the container as unhealthy |
 | sourcebot.livenessProbe.httpGet | object | `{"path":"/api/health","port":"http"}` | Http GET request to check if the container is alive |
 | sourcebot.livenessProbe.httpGet.path | string | `"/api/health"` | Path to check |
@@ -131,6 +132,7 @@ Sourcebot is a self-hosted tool that helps you understand your codebase.
 | sourcebot.startupProbe.httpGet.port | string | `"http"` | Port to check |
 | sourcebot.startupProbe.periodSeconds | int | `30` | Initial delay before the first probe |
 | sourcebot.strategy | object | `{"type":"RollingUpdate"}` | Deployment strategy configuration |
+| sourcebot.terminationGracePeriodSeconds | string | `nil` | Grace period (seconds) Kubernetes waits between SIGTERM and SIGKILL on pod termination. |
 | sourcebot.tolerations | list | `[]` | Set tolerations for pod scheduling See: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 
 ----------------------------------------------

--- a/charts/sourcebot/templates/deployment.yaml
+++ b/charts/sourcebot/templates/deployment.yaml
@@ -30,8 +30,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sourcebot.serviceAccountName" $ }}
-      {{- with $.Values.sourcebot.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ . }}
+      {{- if ne $.Values.sourcebot.terminationGracePeriodSeconds nil }}
+      terminationGracePeriodSeconds: {{ $.Values.sourcebot.terminationGracePeriodSeconds }}
       {{- end }}
       {{- if $.Values.sourcebot.podSecurityContext }}
       securityContext:

--- a/charts/sourcebot/templates/deployment.yaml
+++ b/charts/sourcebot/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "sourcebot.serviceAccountName" $ }}
+      {{- with $.Values.sourcebot.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       {{- if $.Values.sourcebot.podSecurityContext }}
       securityContext:
         {{- toYaml $.Values.sourcebot.podSecurityContext | nindent 8 }}
@@ -116,6 +119,10 @@ spec:
           {{- end }}
           {{- with $.Values.sourcebot.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.sourcebot.lifecycle }}
+          lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/charts/sourcebot/values.schema.json
+++ b/charts/sourcebot/values.schema.json
@@ -167,6 +167,12 @@
         "startupProbe": {
           "type": "object"
         },
+        "lifecycle": {
+          "type": "object"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": ["integer", "null"]
+        },
         "extraVolumes": {
           "type": "array"
         },

--- a/charts/sourcebot/values.yaml
+++ b/charts/sourcebot/values.yaml
@@ -238,6 +238,13 @@ sourcebot:
     # -- Initial delay before the first probe
     periodSeconds: 30
 
+  # -- Container lifecycle hooks.
+  lifecycle: {}
+
+  # -- Grace period (seconds) Kubernetes waits between SIGTERM and SIGKILL on pod
+  # termination.
+  terminationGracePeriodSeconds: null
+
   # -- Define additional volumes
   # See: https://kubernetes.io/docs/concepts/storage/volumes/
   extraVolumes: []


### PR DESCRIPTION
## What

Adds two passthrough values to the Sourcebot deployment:

- `sourcebot.lifecycle` — container lifecycle hooks (e.g. a `preStop` sleep)
- `sourcebot.terminationGracePeriodSeconds` — pod termination grace period

Both default to no-ops (`{}` / `null`), so existing deployments are unchanged.

## Why

On EKS (and other ALB/NLB setups), rolling updates can return brief **502s on the scale-down side**: when the old pod terminates, the load balancer may still route to it for a moment while it deregisters the target. A `preStop` sleep keeps the pod serving during that deregistration window, and `terminationGracePeriodSeconds` ensures the pod isn't SIGKILLed before the sleep + graceful shutdown complete.

Example:

```yaml
sourcebot:
  lifecycle:
    preStop:
      exec:
        command: ["/bin/sh", "-c", "sleep 15"]
  terminationGracePeriodSeconds: 45
```

## Changes

- `templates/deployment.yaml` — render `lifecycle` (container) and `terminationGracePeriodSeconds` (pod spec), guarded by `with` so they're omitted when unset
- `values.yaml` — defaults + documentation
- `values.schema.json` — register both (schema is `additionalProperties: false`)
- `CHANGELOG.md` — `[Unreleased]` entry

## Testing

`helm template` renders both fields correctly when set and omits them at defaults; schema validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pod lifecycle hooks configuration now available, enabling customization of container startup and shutdown behaviors for improved deployment control.
  * Pod termination grace period is now fully configurable, providing flexibility in managing graceful shutdown timing and resource cleanup during pod termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->