### PR TITLE
Default the Sourcebot image to docker.sourcebot.dev

### DIFF
--- a/charts/sourcebot/README.md
+++ b/charts/sourcebot/README.md
@@ -78,7 +78,7 @@ Sourcebot is a self-hosted tool that helps you understand your codebase.
 | sourcebot.image.digest | string | `""` | Container image digest (used instead of tag if set) |
 | sourcebot.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | sourcebot.image.pullSecrets | list | `[]` | Configure image pull secrets for private registries |
-| sourcebot.image.repository | string | `"ghcr.io/sourcebot-dev/sourcebot"` | Container image repository |
+| sourcebot.image.repository | string | `"docker.sourcebot.dev/sourcebot-dev/sourcebot"` | Container image repository |
 | sourcebot.image.tag | string | `""` | Container image tag. Falls back to appVersion if not set. |
 | sourcebot.ingress.annotations | object | `{}` | Ingress annotations |
 | sourcebot.ingress.className | string | `""` | Ingress class name |

--- a/charts/sourcebot/tests/basic_test.yaml
+++ b/charts/sourcebot/tests/basic_test.yaml
@@ -97,7 +97,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "ghcr.io/sourcebot-dev/sourcebot:v1.2.3$"
+          pattern: "docker.sourcebot.dev/sourcebot-dev/sourcebot:v1.2.3$"
         template: deployment.yaml
 
   - it: should use digest when specified
@@ -108,7 +108,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "ghcr.io/sourcebot-dev/sourcebot@sha256:abcdef123456$"
+          pattern: "docker.sourcebot.dev/sourcebot-dev/sourcebot@sha256:abcdef123456$"
         template: deployment.yaml
 
   - it: should set replica count

--- a/charts/sourcebot/values.yaml
+++ b/charts/sourcebot/values.yaml
@@ -33,7 +33,7 @@ sourcebot:
   # Image configuration
   image:
     # -- Container image repository
-    repository: ghcr.io/sourcebot-dev/sourcebot
+    repository: docker.sourcebot.dev/sourcebot-dev/sourcebot
     # -- Container image tag. Falls back to appVersion if not set.
     tag: ""
     # -- Container image digest (used instead of tag if set)


### PR DESCRIPTION
Points the chart's default `image.repository` at `docker.sourcebot.dev/sourcebot-dev/sourcebot` instead of `ghcr.io/sourcebot-dev/sourcebot`, and updates the generated `README.md` row and the two rendered-image test assertions in `tests/basic_test.yaml` to match.

The chart-publish workflow (`.github/workflows/release.yaml`) still pushes the chart to `ghcr.io` OCI and is intentionally unchanged (that's the chart registry, not the app image).

Verified the new host resolves the image: `GET https://docker.sourcebot.dev/v2/sourcebot-dev/sourcebot/manifests/latest` returns 200 (307 reroute in front of ghcr.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)