### PR TITLE
fix: respect PostgreSQL port in database connection

### DIFF
--- a/charts/sourcebot/templates/_helpers.tpl
+++ b/charts/sourcebot/templates/_helpers.tpl
@@ -122,9 +122,7 @@ These will be assembled into DATABASE_URL by the entrypoint.sh script
 */}}
 {{- define "sourcebot.databaseEnv" -}}
 - name: DATABASE_HOST
-  value: {{ include "sourcebot.postgresql.hostname" . | quote }}
-- name: DATABASE_PORT
-  value: {{ .Values.postgresql.port | quote }}
+  value: {{ printf "%s:%v" (include "sourcebot.postgresql.hostname" .) .Values.postgresql.port | quote }}
 - name: DATABASE_USERNAME
   value: {{ .Values.postgresql.auth.username | quote }}
 - name: DATABASE_PASSWORD

--- a/charts/sourcebot/templates/_helpers.tpl
+++ b/charts/sourcebot/templates/_helpers.tpl
@@ -90,6 +90,18 @@ Return PostgreSQL hostname
 {{- end }}
 
 {{/*
+Return PostgreSQL address, preserving a port already included in the hostname
+*/}}
+{{- define "sourcebot.postgresql.address" -}}
+{{- $hostname := include "sourcebot.postgresql.hostname" . -}}
+{{- if regexMatch `^([^:]+|\[[^]]+\]):[0-9]+$` $hostname -}}
+{{- $hostname -}}
+{{- else -}}
+{{- printf "%s:%v" $hostname .Values.postgresql.port -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Return Redis hostname
 */}}
 {{- define "sourcebot.redis.hostname" -}}
@@ -122,7 +134,7 @@ These will be assembled into DATABASE_URL by the entrypoint.sh script
 */}}
 {{- define "sourcebot.databaseEnv" -}}
 - name: DATABASE_HOST
-  value: {{ printf "%s:%v" (include "sourcebot.postgresql.hostname" .) .Values.postgresql.port | quote }}
+  value: {{ include "sourcebot.postgresql.address" . | quote }}
 - name: DATABASE_USERNAME
   value: {{ .Values.postgresql.auth.username | quote }}
 - name: DATABASE_PASSWORD

--- a/charts/sourcebot/tests/basic_test.yaml
+++ b/charts/sourcebot/tests/basic_test.yaml
@@ -158,6 +158,20 @@ tests:
             name: DATABASE_PORT
         template: deployment.yaml
 
+  - it: should preserve a port already included in the external database host
+    values:
+      - ../values.lint.yaml
+    set:
+      postgresql.deploy: false
+      postgresql.host: db.example.test:6543
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_HOST
+            value: db.example.test:6543
+        template: deployment.yaml
+
   - it: should mount persistence volume when enabled
     values:
       - ../values.lint.yaml

--- a/charts/sourcebot/tests/basic_test.yaml
+++ b/charts/sourcebot/tests/basic_test.yaml
@@ -122,6 +122,42 @@ tests:
           value: 3
         template: deployment.yaml
 
+  - it: should include the PostgreSQL port in the bundled database host
+    values:
+      - ../values.lint.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_HOST
+            value: RELEASE-NAME-sourcebot-postgresql:5432
+        template: deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_PORT
+        template: deployment.yaml
+
+  - it: should include a custom PostgreSQL port in the external database host
+    values:
+      - ../values.lint.yaml
+    set:
+      postgresql.deploy: false
+      postgresql.host: db.example.test
+      postgresql.port: 6543
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_HOST
+            value: db.example.test:6543
+        template: deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_PORT
+        template: deployment.yaml
+
   - it: should mount persistence volume when enabled
     values:
       - ../values.lint.yaml


### PR DESCRIPTION
## Summary

- include `postgresql.port` in `DATABASE_HOST` when constructing the database connection
- remove the unsupported `DATABASE_PORT` environment variable
- add regression coverage for bundled and external PostgreSQL configurations

## Testing

- `helm unittest charts/sourcebot --color`
- `helm lint charts/sourcebot -f charts/sourcebot/values.lint.yaml`
- `git diff --check`

SOU-1524

Closes #122

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment-time database connection env vars; misconfiguration could break DB connectivity on upgrade, though behavior aligns with how the app expects the host string.
> 
> **Overview**
> Fixes Helm-generated database env so **non-default PostgreSQL ports** actually reach the app.
> 
> `DATABASE_HOST` is now built via a new `sourcebot.postgresql.address` helper: hostname plus `postgresql.port`, unless the host value already includes a port (including bracketed IPv6). The separate **`DATABASE_PORT` env var is removed** because entrypoint/`DATABASE_URL` assembly only used host.
> 
> Adds **helm unittest** cases for bundled Postgres, external host + custom port, and host strings that already contain a port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82ea812a8ad2e8cb701d7ffa3621972ab204646c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database connection settings to include the PostgreSQL port directly in the database host value.
  * Improved compatibility with both bundled and externally managed PostgreSQL databases.
  * Removed the separate database port setting from the generated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->