### PR TITLE
fix: authorize vulnerability alert reads

### DIFF
--- a/.github/workflows/vulnerability-triage.yml
+++ b/.github/workflows/vulnerability-triage.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   packages: read
   security-events: read
+  vulnerability-alerts: read
   id-token: write
 
 jobs:


### PR DESCRIPTION
The scheduled vulnerability triage started failing after the shared reusable workflow began requesting `vulnerability-alerts: read`.

Grant that permission in the caller so GitHub can start the reusable workflow and query Dependabot alerts.

Validation: YAML parsing and `git diff --check` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI permission addition with no application or data-path changes.
> 
> **Overview**
> Adds **`vulnerability-alerts: read`** to the scheduled **Vulnerability Triage** caller workflow’s `permissions` block.
> 
> The reusable `sourcebot-dev/sourcebot` triage workflow now needs that scope to read Dependabot alerts; without it on the caller, GitHub won’t start the job after the upstream change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c006bca75ead0aa746a225451f5f95a6f024b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security workflow access configuration for vulnerability alert checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->