### PR TITLE
feat(sourcebot): add hostAliases support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `sourcebot.hostAliases` value for injecting entries into the pod's `/etc/hosts`. [#NNN](https://github.com/sourcebot-dev/sourcebot-helm-chart/pull/NNN)
+
 ## [0.1.101] - 2026-08-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `sourcebot.hostAliases` value for injecting entries into the pod's `/etc/hosts`. [#NNN](https://github.com/sourcebot-dev/sourcebot-helm-chart/pull/NNN)
+- `sourcebot.hostAliases` value for injecting entries into the pod's `/etc/hosts`. [131](https://github.com/sourcebot-dev/sourcebot-helm-chart/pull/131)
 
 ## [0.1.101] - 2026-08-13
 

--- a/charts/sourcebot/README.md
+++ b/charts/sourcebot/README.md
@@ -75,6 +75,7 @@ Sourcebot is a self-hosted tool that helps you understand your codebase.
 | sourcebot.envFrom | list | `[]` | Load environment variables from ConfigMaps and Secrets This is useful for injecting multiple environment variables from external secret management systems |
 | sourcebot.extraVolumeMounts | list | `[]` | Define volume mounts for the container See: https://kubernetes.io/docs/concepts/storage/volumes/ |
 | sourcebot.extraVolumes | list | `[]` | Define additional volumes See: https://kubernetes.io/docs/concepts/storage/volumes/ |
+| sourcebot.hostAliases | list | `[]` | Set host aliases to inject entries into the pod's /etc/hosts file See: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/ |
 | sourcebot.image.digest | string | `""` | Container image digest (used instead of tag if set) |
 | sourcebot.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | sourcebot.image.pullSecrets | list | `[]` | Configure image pull secrets for private registries |

--- a/charts/sourcebot/templates/deployment.yaml
+++ b/charts/sourcebot/templates/deployment.yaml
@@ -167,3 +167,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $.Values.sourcebot.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/sourcebot/values.schema.json
+++ b/charts/sourcebot/values.schema.json
@@ -201,7 +201,18 @@
           "type": "array"
         },
         "hostAliases": {
-          "type": "array"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "ip": { "type": "string" },
+              "hostnames": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            },
+            "required": ["ip"]
+          }
         },
         "affinity": {
           "type": "object"

--- a/charts/sourcebot/values.schema.json
+++ b/charts/sourcebot/values.schema.json
@@ -200,6 +200,9 @@
         "tolerations": {
           "type": "array"
         },
+        "hostAliases": {
+          "type": "array"
+        },
         "affinity": {
           "type": "object"
         },

--- a/charts/sourcebot/values.yaml
+++ b/charts/sourcebot/values.yaml
@@ -297,6 +297,13 @@ sourcebot:
   #   operator: Equal
   #   value: "value"
 
+  # -- Set host aliases to inject entries into the pod's /etc/hosts file
+  # See: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+  hostAliases: []
+  # - ip: "10.0.0.10"
+  #   hostnames:
+  #     - "gitlab.internal.example.com"
+
   # -- Set affinity rules for pod scheduling
   # Defaults to soft anti-affinity if not set
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/


### PR DESCRIPTION
## What

Adds a `sourcebot.hostAliases` value that maps to the pod's `hostAliases` field,
allowing custom entries to be injected into `/etc/hosts`.

## Why

When Sourcebot runs in a cluster whose DNS cannot resolve an internal code host
(self-hosted GitLab / GitHub Enterprise behind split-DNS, or a host that is only
reachable by IP), connections fail to sync. `hostAliases` is the standard
Kubernetes escape hatch for this, and it is currently not exposed by the chart.

## Changes

- `templates/deployment.yaml`: render `hostAliases` in the pod spec, following the
  same `with` + `toYaml | nindent 8` pattern used by `nodeSelector` / `tolerations`
- `values.yaml`: new `sourcebot.hostAliases` key (defaults to `[]`), documented in
  the same style as the neighbouring `tolerations` block
- `values.schema.json`: declare the key as `array`, consistent with how other
  pass-through arrays (`tolerations`, `extraVolumes`) are declared
- `values.lint.yaml`: sample value so the new block is actually exercised in CI
- `README.md`: regenerated with `helm-docs --chart-search-root ./charts`
- `CHANGELOG.md`: entry under `[Unreleased]`

## Backwards compatibility

Default is `[]`, so the block is omitted entirely and rendered output is unchanged
for existing installations.

## Testing

- `helm lint ./charts/sourcebot -f ./charts/sourcebot/values.lint.yaml` passes
- `helm template` renders the block as expected, and omits it with default values
- Deployed to a live cluster and confirmed the entry appears in the pod's
  `/etc/hosts` via `kubectl exec deploy/sourcebot -- cat /etc/hosts`

I did not bump the chart version in `Chart.yaml` — happy to do so if you prefer
that in contributor PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4c15561a387d9b31d286cb26fc0d2bfafb6f0e4e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional host alias configuration for Helm deployments.
  - Configure custom hostname-to-IP mappings in the application pod’s `/etc/hosts` file.
  - The setting defaults to an empty list and supports validated IP addresses and hostnames.

- **Documentation**
  - Documented the host alias configuration in the Helm chart README and changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->